### PR TITLE
Coverage optional

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,8 +37,13 @@ Coverage
 
 As of version 0.3.0, there is (experimental) support for `coverage <http://nedbatchelder.com/code/coverage/>`_.
 
-Run your tests as normal (``python manage.py test <whatever>``), and if you
+Use
+
+    TEST_RUNNER = 'rainbowtests.test.runner.RainbowDiscoverCoverageRunner'
+
+and run your tests as normal (``python manage.py test <whatever>``), and if you
 have coverage installed, you should see a report when your tests complete.
+You could also use ``coverage html`` and open ``htmlcov/index.html`` for a more fancy coverage report.
 Make sure you have a ``.coveragerc`` file, though!
 
 

--- a/rainbowtests/messages.py
+++ b/rainbowtests/messages.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import random
-from rainbowtests import colors
+from random import choice
 
+from rainbowtests import colors
 
 happy_messages = []
 sad_messages = []
@@ -54,8 +54,12 @@ sad_messages.append("""
 
 
 def random_happy():
-    return colors.green(random.choice(happy_messages))
+    return colors.green(choice(happy_messages))
 
 
 def random_sad():
-    return colors.red(random.choice(sad_messages))
+    return colors.red(choice(sad_messages))
+
+
+def random(success):
+    return random_happy() if success else random_sad()

--- a/rainbowtests/test/core.py
+++ b/rainbowtests/test/core.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import django
 import sys
 import unittest
-
 from inspect import getfile
 from os.path import dirname
+
+import django
 
 from rainbowtests import colors
 

--- a/rainbowtests/test/runner.py
+++ b/rainbowtests/test/runner.py
@@ -3,9 +3,11 @@
 
 import unittest
 
+from django.conf import settings
 from django.test.runner import DiscoverRunner
-from rainbowtests.test.core import RainbowTextTestResult, ColorfulOut
+
 from rainbowtests import messages
+from rainbowtests.test.core import ColorfulOut, RainbowTextTestResult
 
 try:
     import coverage
@@ -15,13 +17,6 @@ except ImportError:
 
 class RainbowDiscoverRunner(DiscoverRunner):
     """Replacement for Django's DiscoverRunner"""
-
-    def __init__(self, *args, **kwargs):
-        super(RainbowDiscoverRunner, self).__init__(*args, **kwargs)
-        self._cov = None
-        if coverage:
-            self._cov = coverage.coverage()
-            self._cov.start()
 
     def run_suite(self, suite, **kwargs):
         if not hasattr(self, "test_runner"):
@@ -35,14 +30,22 @@ class RainbowDiscoverRunner(DiscoverRunner):
         runner.resultclass = RainbowTextTestResult
         result = runner.run(suite)
 
-        if result.wasSuccessful():
-            runner.stream.writeln(messages.random_happy())
-        else:
-            runner.stream.writeln(messages.random_sad())
+        runner.stream.writeln(messages.random(result.wasSuccessful()))
         return result
 
+
+class RainbowDiscoverCoverageRunner(RainbowDiscoverRunner):
+    """Replacement for Django's DiscoverRunner with coverage support"""
+
+    def __init__(self, *args, **kwargs):
+        super(RainbowDiscoverCoverageRunner, self).__init__(*args, **kwargs)
+        self._cov = None
+        if coverage:
+            self._cov = coverage.coverage()
+            self._cov.start()
+
     def suite_result(self, suite, result, **kwargs):
-        result = super(RainbowDiscoverRunner, self).suite_result(
+        result = super(RainbowDiscoverCoverageRunner, self).suite_result(
             suite, result, **kwargs
         )
         if coverage and self._cov:

--- a/rainbowtests/test/simple.py
+++ b/rainbowtests/test/simple.py
@@ -5,7 +5,9 @@
 # We should remove it at some point?
 
 import unittest
+
 from django.test.simple import DjangoTestSuiteRunner
+
 from rainbowtests import messages
 from rainbowtests.test.core import RainbowTextTestResult
 


### PR DESCRIPTION
Fix #5 by introducing a Rainbow runner with coverage enabled (`RainbowDiscoverCoverageRunner`) and removing the coverage stuff from `RainbowDiscoverRunner`.

 - Documented the change.
 - Sorted the imports consistently with [isort](https://github.com/timothycrosley/isort/)

If you don't like this way of fixing #5, let me know, I'll be happy to solve it differently.