### PR TITLE
Remove gender since it is not relevant

### DIFF
--- a/rainbowtests/messages.py
+++ b/rainbowtests/messages.py
@@ -18,7 +18,7 @@ happy_messages.append("""
 
 happy_messages.append("""
 
-        (☞ﾟ∀ﾟ)☞ You da Man!
+        (☞ﾟ∀ﾟ)☞ You rock!
         All tests passed.
 
 """)


### PR DESCRIPTION
Gender isn't relevant to coding or tests. This isn't an attack, just someone on my team mentioned they'd like it if our test runner didn't call them a man. Fair enough.