### PR TITLE
Make random message output a user setting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,6 +21,12 @@ ends up highlighting more than you need or want).::
 
     RAINBOWTESTS_HIGHLIGHT_PATH = '/path/to/my/project/'
 
+If the test output is too verbose and you just want a colorful version of
+the standard Django test output, set ``RAINBOWTESTS_SHOW_MESSAGES`` to
+``False``::
+
+    RAINBOWTESTS_SHOW_MESSAGES = False
+
 Django > 1.6: Set your test runner to the ``RainbowDiscoverRunner``::
 
     TEST_RUNNER = 'rainbowtests.test.runner.RainbowDiscoverRunner'

--- a/rainbowtests/test/runner.py
+++ b/rainbowtests/test/runner.py
@@ -18,6 +18,17 @@ except ImportError:
 class RainbowDiscoverRunner(DiscoverRunner):
     """Replacement for Django's DiscoverRunner"""
 
+    def __init__(self, *args, **kwargs):
+        super(RainbowDiscoverRunner, self).__init__(*args, **kwargs)
+        self._set_messages_display()
+
+    def _set_messages_display(self):
+        """Don't show messages if the user doesn't want them"""
+        try:
+            self.show_messages = settings.RAINBOWTESTS_SHOW_MESSAGES
+        except AttributeError:
+            self.show_messages = True
+
     def run_suite(self, suite, **kwargs):
         if not hasattr(self, "test_runner"):
             # This was added as a clas attribute in Django 1.7
@@ -30,7 +41,8 @@ class RainbowDiscoverRunner(DiscoverRunner):
         runner.resultclass = RainbowTextTestResult
         result = runner.run(suite)
 
-        runner.stream.writeln(messages.random(result.wasSuccessful()))
+        if self.show_messages:
+            runner.stream.writeln(messages.random(result.wasSuccessful()))
         return result
 
 


### PR DESCRIPTION
Sometimes the user simply wants to have colour in the standard Django
test output.  Coloured output definitely helps development, since it
makes test failures or skips much more obvious.  The random message is
amusing, however can be annoying for some users as well as taking up
screen real estate that one would rather use for traceback text.  This
change adds the RAINBOWTESTS_SHOW_MESSAGES option, which the user can
set in their `settings.py`.  The default behaviour is maintained but now
the user has the choice of random message output or not.

This pull request is submitted in the hope that it is useful.  If you wish to have it updated in some way (e.g. the `_set_messages_display()` should be defined elsewhere), please let me know and I'll happily update the PR and resubmit.